### PR TITLE
nunjucks version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "fs": "0.0.2",
     "loader-utils": "^0.2.11",
-    "nunjucks": "^1.3.4",
+    "nunjucks": "^2.4.2",
     "path": "^0.11.14"
   },
   "devDependencies": {}


### PR DESCRIPTION
Hi @ryanhornberger ,

Nunjucks v1.x depends on [fsevents](https://www.npmjs.com/package/fsevents) library which uses deprecated apis in node v6 (https://github.com/strongloop/fsevents/issues/127). To fix the "issue" I have bumped nunjucks to v2.4.2. It seems to be working fine.
