### PR TITLE
add support for front-matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,13 @@ module.exports = function(content) {
 
 	var nunjEnv = new nunjucks.Environment(loader);
 	nunjucks.configure(null, { watch: false });
+
+    try {
+        var frontmatter = JSON.parse(content)
+        content = frontmatter.body
+        nunjucksContext = Object.assign({}, nunjucksContext, frontmatter.attributes)
+    }
+    catch(e) {}
 	
 	var template = nunjucks.compile(content, nunjEnv);
 	html = template.render(nunjucksContext);


### PR DESCRIPTION
Hey guys,

Would you be interested in merging this?
- https://www.npmjs.com/package/front-matter (assigns context from YAML metadata)

It allows for templates like this:

```html
---
title: Just hack'n
description: Nothing to see here
---
 
<h1>{{ title }}</h1>
<p>{{ description }}</p>
```