### PR TITLE
Update loader-utils: Prevents critical audit failures for package users

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(content) {
 	this.cacheable();
   
 	var callback = this.async();
-	var opt = utils.parseQuery(this.query);
+	var opt = this.getOptions();
 
 	var nunjucksSearchPaths = opt.searchPaths;
 	var nunjucksContext = opt.context;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "^0.2.16",
-    "nunjucks": "^3.0.0"
+    "loader-utils": "^3.2.1",
+    "nunjucks": "^3.2.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Fixes #11 

While users of this library can always add suppression for this library, it's probably better to simply update the dependencies.